### PR TITLE
[Feat] board 등록, 수정, 삭제 api 구현 & modal 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ function App() {
           <Route path="/board" element={<BoardListPage />} />
           <Route path="/board/:boardId" element={<BoardDetailPage />} />
           <Route path="/board/write" element={<WritePage />} />
+          <Route path="/board/edit/:boardId" element={<WritePage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -6,7 +6,7 @@ const Header = ({ uploadHandler }) => {
   const nav = useNavigate();
   const location = useLocation();
   const isHome = location.pathname == '/home';
-  const isWritePage = location.pathname == '/board/write';
+  const isWritePage = location.pathname == '/board/write' || location.pathname.includes('/edit');
 
   return (
     <div

--- a/src/pages/BoardDetailPage.jsx
+++ b/src/pages/BoardDetailPage.jsx
@@ -1,90 +1,156 @@
 import { useEffect, useState } from "react";
-import newsData from "@/constants/newslist/newsData";
+import { useNavigate, useParams } from "react-router-dom";
 import summary from '@/assets/svgs/common/summary.svg';
 import pencil from '@/assets/svgs/board/pencil.svg';
 import trash from '@/assets/svgs/board/trash.svg';
 import paper_clip from '@/assets/webps/board/paper_clip.webp'
 import download from '@/assets/svgs/board/download.svg';
+import instance from "@/apis/instance";
+import Modal from '@/components/ui/Modal';
 
 const BoardDetailPage = () => {
   const [board, setBoard] = useState({});
-  const [isWriter, setIsWriter] = useState(false);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const { boardId } = useParams();
+  const nav = useNavigate();
+  const errorMessage = '요청을 처리하는 데 실패하였습니다.';
+  
+  const [modalMessage, setModalMessage] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const closeModal = () => setIsModalOpen(false);
+  const openModal = (message) => {
+    setModalMessage(message);
+    setIsModalOpen(true);
+  };
 
-  const deleteHandler = () => {
-    console.log('삭제');
+  const editHandler = () => {
+    if (!board.owner) {
+      openModal('수정 권한이 없습니다.');
+      return;
+    }
+
+    nav(`/board/edit/${boardId}`)
   }
 
-  const downloadHandler = () => {
-    console.log('요약본 다운');
+  const deleteHandler = async () => {
+    if (!board.owner && !board.admin) {
+      openModal('삭제 권한이 없습니다.');
+      return;
+    }
+
+    try {
+      const res = await instance.delete(`/apps/board/${boardId}`
+        // 테스트 데이터
+        , {headers: { 'X-USER-ID': boardId, 'X-User-Role': 'USER' }}
+      );
+  
+      if (res.status === 200) {
+        nav('/board');
+      }
+    } catch (error) {
+      console.log('BoardDetail - deleteHandler() ::: ', error);
+      openModal(errorMessage);
+    }
   }
+
+  const downloadHandler = async () => {
+    try {
+      const res = await instance.get(`/apps/board/${boardId}/download`, {
+        responseType: 'blob'
+      });
+  
+      if (res.data.size === 0) {
+        throw new Error('파일 내용이 비어 있습니다.');
+      }
+  
+      const url = window.URL.createObjectURL(new Blob([res.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `${board.board_title}.pdf`);
+      document.body.appendChild(link);
+      link.click();
+  
+      document.body.removeChild(link);
+    } catch (error) {
+      console.log('BoardDetail - downloadHandler() :: ', error);
+      openModal(errorMessage);
+    }
+  }
+
+  const fetchBoardData = async () => {
+    try {
+      const res = await instance.get(`/apps/board/${boardId}`
+        // 테스트 데이터
+        , {headers: { 'X-USER-ID': boardId, 'X-User-Role': 'USER' }}
+      );
+  
+      if (res.data) {
+        setBoard(res.data);
+      }
+    } catch (error) {
+      console.log('BoardDetail - fetchBoard() ::: ', error);
+      openModal(errorMessage);
+    }
+  };
 
   useEffect(() => {
-    setBoard({
-      boardTitle: "새로운 '아이폰 16E'? SE는 이제 역사 속으로?",
-      hitCnt: 5,
-      writer: "킷챠",
-      boardDate: "2025-02-21T22:51:56.591609".split("T")[0],
-      content: "성능 면에서는 확실한 진화지만, SE 특유의 '작은 크기 + 홈 버튼' 조합이 사라진다면 기존 팬들에게는 아쉬운 변화일 수도 있다. \
-      가격이 70-80만 원 대로 책정될 경우, 아이폰 13 리퍼 모델과 경쟁해야 하는 점도 변수다. \
-      \nSE의 정체성을 유지한 가성비 모델로 자리 잡을지, 완전히 새로운 라인업으로 바뀔지 지켜볼 필요가 있다. 여러분은 어떻게 생각하시나요?😀",
-      longSummary: newsData[0].long_summary,
-      newsUrl: newsData[0].news_url
-    });
+    fetchBoardData();
   }, []);
 
   return (
-    <div className="mx-[30px] mt-5 mb-[50px] tracking-normal">
-      <div className="flex justify-between">
-        <span className="text-xs text-[#BC56F3]">{board.writer}</span>
-        <div className="flex space-x-[10px]">
-          <span className="text-[10px] text-[#919191]">조회수 {board.hitCnt}</span>
-          <span className="text-[10px] text-[#2E2E2E] mr-[6px]">{board.boardDate}</span>
+    <>
+      <Modal isOpen={isModalOpen} message={modalMessage} onClose={closeModal} />
+      <div className="mx-[30px] mt-5 mb-[50px] tracking-normal">
+        <div className="flex justify-between">
+          <span className="text-xs text-[#BC56F3]">{board.writer}</span>
+          <div className="flex space-x-[10px]">
+            <span className="text-[10px] text-[#919191]">조회수 {board.hit_cnt}</span>
+            <span className="text-[10px] text-[#2E2E2E] mr-[6px]">{board?.board_date?.split("T")[0]}</span>
+          </div>
         </div>
-      </div>
-      <h1 className="mt-[2px] text-lg font-bold">{board.boardTitle}</h1>
-      {/* 아이콘 */}
-      <div className="flex justify-between items-center px-1 mt-[6px]">
-        <div className="flex space-x-4">
-          {isWriter && (
-              <>
-                <img src={pencil} className="w-4 h-4 cursor-pointer" />
-                <img src={trash} className="w-4 h-4 cursor-pointer" onClick={deleteHandler} />
-              </>
+        <h1 className="mt-[2px] text-lg font-bold">{board.board_title}</h1>
+        {/* 아이콘 */}
+        <div className="flex justify-between items-center px-1 mt-[6px]">
+          <div className="flex space-x-4">
+            {board.owner && (
+                <>
+                  <img src={pencil} className="w-4 h-4 cursor-pointer" onClick={editHandler} />
+                  <img src={trash} className="w-4 h-4 cursor-pointer" onClick={deleteHandler} />
+                </>
+            )}
+          </div>
+          {!board.admin && (
+            <div className="flex space-x-1">
+              <span className="text-[10px] text-[#BC56F3]">원문 보기</span>
+              <a
+                href={board.news_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <img src={paper_clip} className="w-5 h-5 mr-3" />
+              </a>
+              <span className="text-[10px] text-[#BC56F3]">요약본 다운</span>
+              <img src={download} className="w-4 h-4 cursor-pointer" onClick={downloadHandler} />
+            </div>
+          )}
+          {board.admin && (
+            <div className="ml-auto">
+              <img src={trash} className="w-4 h-4 cursor-pointer" onClick={deleteHandler} />
+            </div>
           )}
         </div>
-        {!isAdmin && (
-          <div className="flex space-x-1">
-            <span className="text-[10px] text-[#BC56F3]">원문 보기</span>
-            <a
-              href={board.newsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <img src={paper_clip} className="w-5 h-5 mr-3" />
-            </a>
-            <span className="text-[10px] text-[#BC56F3]">요약본 다운</span>
-            <img src={download} className="w-4 h-4 cursor-pointer" onClick={downloadHandler} />
-          </div>
-        )}
-        {isAdmin && (
-          <div className="ml-auto">
-            <img src={trash} className="w-4 h-4 cursor-pointer" onClick={deleteHandler} />
-          </div>
-        )}
-      </div>
-      {/* 요약 */}
-      <div className="mt-3 rounded-2xl flex space-x-2 py-4 pl-3 pr-5 shadow-[0_0_5px_rgba(0,0,0,0.1)]">
-        <img src={summary} className="w-[14px] h-[14px]" />
-        <p className="text-sm text-[#363636] whitespace-pre-wrap leading-relaxed">
-          {board.longSummary}
+        {/* 요약 */}
+        <div className="mt-3 rounded-2xl flex space-x-2 py-4 pl-3 pr-5 shadow-[0_0_5px_rgba(0,0,0,0.1)]">
+          <img src={summary} className="w-[14px] h-[14px]" />
+          <p className="text-sm text-[#363636] whitespace-pre-wrap leading-relaxed">
+            {board.long_summary}
+          </p>
+        </div>
+        {/* 본문 */}
+        <p className="w-full font-normal mt-7 bg-[#FBF4FF] rounded-[10px] p-4 text-sm whitespace-pre-line leading-relaxed">
+          {board.content}
         </p>
       </div>
-      {/* 본문 */}
-      <p className="w-full font-normal mt-7 bg-[#FBF4FF] rounded-[10px] p-4 text-sm whitespace-pre-line leading-relaxed">
-        {board.content}
-      </p>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/BoardListPage.jsx
+++ b/src/pages/BoardListPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import instance from "@/apis/instance";
+import Modal from '@/components/ui/Modal';
 
 const BoardListPage = () => {
   const nav = useNavigate();
@@ -10,24 +11,32 @@ const BoardListPage = () => {
   const [boardList, setBoardList] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
 
+  const [modalMessage, setModalMessage] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const closeModal = () => setIsModalOpen(false);
+  const openModal = (message) => {
+    setModalMessage(message);
+    setIsModalOpen(true);
+  };
+
   const fetchBoardList = async () => {
     if (isLoading) return;
     setIsLoading(true);
 
     try {
-      await instance.get(`/apps/board?page=${page}&size=10`)
-        .then((res) => {
-          if (res.data) {
-            if (res.data.length < 10) {
-              setHasMore(false);
-            } else {
-              setBoardList((prevList) => [...prevList, ...res.data]);
-              setPage((prevPage) => prevPage + 1);
-            }
-          }
-        });
+      const res = await instance.get(`/apps/board?page=${page}&size=10`);
+
+      if (res.data) {
+        if (res.data.length === 0) {
+          setHasMore(false);
+        } else {
+          setBoardList((prevList) => [...prevList, ...res.data]);
+          setPage((prevPage) => prevPage + 1);
+        }
+      }
     } catch (error) {
-      console.log(error);
+      console.log('BoardList - fetchBoardList() ::: ', error);
+      openModal('요청을 처리하는 데 실패하였습니다');
     } finally {
       setIsLoading(false);
     }
@@ -56,26 +65,29 @@ const BoardListPage = () => {
   }, [hasMore, page]);
 
   return (
-    <div className="px-[30px] mt-[46px] mb-[26px] space-y-4">
-        {boardList && boardList.map((board, index) => (
-          <div
-            key={index}
-            className="space-y-3 cursor-pointer"
-            onClick={() => nav(`/board/${board.boardId}`)}
-          >
-            <h2 className="text-base font-bold px-1">{board.boardTitle}</h2>
-            <div className="flex justify-between px-1">
-              <span className="text-xs text-[#BC56F3]">{board.writer}</span>
-              <div className="flex space-x-[10px]">
-                <span className="text-[10px] text-[#919191]">조회수 {board.hitCnt}</span>
-                <span className="text-[10px] text-[#2E2E2E]">{board?.boardDate?.split("T")[0]}</span>
+    <>
+      <Modal isOpen={isModalOpen} message={modalMessage} onClose={closeModal} />
+      <div className="px-[30px] mt-[46px] mb-[26px] space-y-4">
+          {boardList && boardList.map((board, index) => (
+            <div
+              key={index}
+              className="space-y-3 cursor-pointer"
+              onClick={() => nav(`/board/${board.board_id}`)}
+            >
+              <h2 className="text-base font-bold px-1">{board.board_title}</h2>
+              <div className="flex justify-between px-1">
+                <span className="text-xs text-[#BC56F3]">{board.writer}</span>
+                <div className="flex space-x-[10px]">
+                  <span className="text-[10px] text-[#919191]">조회수 {board.hit_cnt}</span>
+                  <span className="text-[10px] text-[#2E2E2E]">{board?.board_date?.split("T")[0]}</span>
+                </div>
               </div>
+              <div className="h-[1px] w-full transition-colors bg-[#B1B1B1]" />
             </div>
-            <div className="h-[1px] w-full transition-colors bg-[#B1B1B1]" />
-          </div>
-        ))}
-        {hasMore && <div ref={elementRef}></div>}
-    </div>
+          ))}
+          {hasMore && <div ref={elementRef}></div>}
+      </div>
+    </>
   );
 };
 

--- a/src/pages/WritePage.jsx
+++ b/src/pages/WritePage.jsx
@@ -1,25 +1,117 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
+import { useLocation, useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import summary from '@/assets/svgs/common/summary.svg';
+import Modal from '@/components/ui/Modal';
+import instance from '@/apis/instance';
 
 const WritePage = () => {
   // Layout에서 전달된 핸들러 설정 함수
   const { setUploadHandler } = useOutletContext();
-  const nav = useNavigate();
+  const { boardId } = useParams();
   const location = useLocation();
+  const isEdit = location.pathname.includes('/edit');
+  const nav = useNavigate();
 
   const news = location.state;
-  const [board, setBoard] = useState({
-    boardId: null,
-    boardTitle: '',
-    content: '',
-    newsTitle: '',
-    summary: news.long_summary,
-    url: news.news_url,
-  });
+  const [board, setBoard] = useState({});
 
-  const uploadHandler = () => {
-    // nav(`/board/${boardId}`);
+  const [modalMessage, setModalMessage] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const closeModal = () => setIsModalOpen(false);
+  const openModal = (message) => {
+    setModalMessage(message);
+    setIsModalOpen(true);
+  };
+
+  const fetchBoardData = async () => {
+    if (isEdit) {
+      try {
+        const res = await instance.get(`/apps/board/${boardId}`
+          // 테스트 데이터
+          ,{headers: { 'X-USER-ID': boardId, 'X-User-Role': 'owner'}}
+        );
+        setBoard({
+          board_id: res.data.board_id,
+          board_title: res.data.board_title,
+          content: res.data.content,
+          long_summary: res.data.long_summary,
+          news_url: res.data.news_url,
+          owner: res.data.owner
+        });
+      } catch (error) {
+        openModal('요청을 처리하는 데 실패하였습니다.');
+      }
+    } else {
+      setBoard({    
+        board_id: null,
+        board_title: '',
+        content: '',
+        long_summary: news?.long_summary || '',
+        news_url: news?.news_url || '',
+        owner: false
+      });
+    }
+  }
+
+  useEffect(() => {
+    fetchBoardData();
+  }, [isEdit, boardId]);
+
+  const uploadHandler = async () => {
+    if(!board.board_title.trim()) {
+      openModal('제목을 입력해주세요.');
+      return;
+    }
+    
+    if (!board.content.trim()) {
+      openModal('내용을 입력해주세요.');
+      return;
+    }
+
+    try {
+      if (isEdit && !board.owner) {
+        openModal('수정 권한이 없습니다.');
+        return;
+      }
+
+      // 수정
+      if (isEdit && board.owner) {
+        await instance.put(`/apps/board/${boardId}`, {
+          board_title: board.board_title,
+          content: board.content,
+        }
+        // 테스트 데이터
+        , {headers: {'X-User-Id' : boardId}}
+        );
+        
+        nav(`/board/${boardId}`);
+      } else {
+        // 작성
+        const param = {
+          board_id: null,
+          board_title: board.board_title,
+          content: board.content,
+          news_title: news.news_title,
+          summary: board.long_summary,
+          url: board.news_url,
+        }
+
+        // 테스트 변수
+        const config = {
+          headers: {
+            'X-User-Id': 1,
+            'X-User-Nickname': 'kitcha'
+          }
+        };
+
+        const res = await instance.post('/apps/board', param, config);
+
+        nav(`/board/${res.data.board_id}`);
+      }
+    } catch (error) {
+      console.log('Write - uploadHandler() :: ', error);
+      openModal('요청을 처리하는 데 실패하였습니다.');
+    }
   };
 
   const onChangeHandler = (name, value) => {
@@ -30,41 +122,56 @@ const WritePage = () => {
   };
 
   const handleResize = (e) => {
-    e.target.style.height = 'auto';
-    e.target.style.height = `${e.target.scrollHeight}px`;
+    const textarea = e.target;
+    const minHeight = 27;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.max(textarea.scrollHeight, minHeight)}px`;
   };
+
+  useEffect(() => {
+    // 최초 로드 시, 제목란의 높이를 자동으로 설정
+    const textarea = document.querySelector('.board-title');
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${Math.max(textarea.scrollHeight, 27)}px`;
+    }
+  }, [board.board_title]);
 
   useEffect(() => {
     setUploadHandler(() => uploadHandler);
     return () => setUploadHandler(null);
-  }, [board.boardTitle, board.content]);
+  }, [board.board_title, board.content]);
 
   return (
-    <div className="px-[30px] mt-[46px] mb-[50px] tracking-normal">
-      <div className="space-y-1">
-        <textarea
-          rows={1}
-          placeholder="제목을 입력하세요"
-          value={board.boardTitle}
-          onChange={(e) => onChangeHandler('boardTitle', e.target.value)}
-          onInput={handleResize} // 입력 시 자동으로 크기 조정
-          className="font-nanum font-bold w-full px-[5px] h-[27px] outline-none resize-none"
-        />
-        <div className="h-[1px] w-full transition-colors bg-[#B1B1B1]" />
-      </div>
-      <div className="mt-[52px] rounded-2xl flex space-x-2 py-4 pl-3 pr-5 shadow-[0_0_5px_rgba(0,0,0,0.1)]">
-        <img src={summary} className="w-[14px] h-[14px]" />
-        <div className="text-sm text-[#363636] whitespace-pre-wrap leading-relaxed">
-          {board.summary}
+    <>
+      <Modal isOpen={isModalOpen} message={modalMessage} onClose={closeModal} />
+      <div className="px-[30px] mt-[46px] mb-[50px] tracking-normal">
+        <div className="space-y-1">
+          <textarea
+            rows={1}
+            placeholder="제목을 입력하세요"
+            value={board.board_title}
+            onChange={(e) => onChangeHandler('board_title', e.target.value)}
+            onInput={handleResize} // 입력 시 자동으로 크기 조정
+            className="board-title font-nanum font-bold w-full px-[5px] outline-none resize-none"
+            style={{ minHeight: '27px', overflow: 'hidden' }}  // 스타일 추가
+          />
+          <div className="h-[1px] w-full transition-colors bg-[#B1B1B1]" />
         </div>
+        <div className="mt-[52px] rounded-2xl flex space-x-2 py-4 pl-3 pr-5 shadow-[0_0_5px_rgba(0,0,0,0.1)]">
+          <img src={summary} className="w-[14px] h-[14px]" />
+          <div className="text-sm text-[#363636] whitespace-pre-wrap leading-relaxed">
+            {board.long_summary}
+          </div>
+        </div>
+        <textarea
+          placeholder="기사에 대한 의견을 공유해주세요!"
+          value={board.content}
+          onChange={(e) => onChangeHandler('content', e.target.value)}
+          className="w-full h-[214px] mt-7 rounded-[10px] p-4 text-sm resize-none shadow-[inset_0_0_0_1px_#B1B1B1] outline-none"
+        />
       </div>
-      <textarea
-        placeholder="기사에 대한 의견을 공유해주세요!"
-        value={board.content}
-        onChange={(e) => onChangeHandler('content', e.target.value)}
-        className="w-full h-[214px] mt-7 rounded-[10px] p-4 text-sm resize-none shadow-[inset_0_0_0_1px_#B1B1B1] outline-none"
-      />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📎 작업 내용
- WritePage 저장, 수정, 삭제 api 연동
- BoardDetail 요약본 다운로드 api 연동
- 유효성 검증, API 호출 실패 시 모달 띄우기

### 💡 공통
- Header: WriterPage 수정일 때 uri 추가, 업로드 버튼 노출 조건 수정

## 📷 작업 화면 스크린샷
- WritePage 작성, 원문보기, 요약본 다운로드
- 아직은 사용자 인증 로직이 없는 관계로 작성 후 수정, 삭제 아이콘 안 보입니다
https://github.com/user-attachments/assets/fd2fcf6f-d65d-44db-80fc-61bba6fdfcf0

- WritePage 수정, 삭제
https://github.com/user-attachments/assets/db1f164c-5e7d-489f-8ee2-f89874db2d14

- WritePage 제목, 본문 유효성 검증 실패 Modal
![image](https://github.com/user-attachments/assets/49190b43-9b8c-49dd-ad84-87d85088a07b)
![image](https://github.com/user-attachments/assets/1de8d514-644f-4a49-a21e-5426d5a3df28)
