### PR TITLE
[Fix] List 화면들 제목 말줄임 처리

### DIFF
--- a/src/pages/BoardListPage.jsx
+++ b/src/pages/BoardListPage.jsx
@@ -74,7 +74,7 @@ const BoardListPage = () => {
               className="space-y-3 cursor-pointer"
               onClick={() => nav(`/board/${board.board_id}`)}
             >
-              <h2 className="text-base font-bold px-1">{board.board_title}</h2>
+              <h2 className="text-base font-bold px-1 overflow-hidden text-ellipsis whitespace-nowrap">{board.board_title}</h2>
               <div className="flex justify-between px-1">
                 <span className="text-xs text-[#BC56F3]">{board.writer}</span>
                 <div className="flex space-x-[10px]">

--- a/src/pages/NewsListPage.jsx
+++ b/src/pages/NewsListPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import summary from '@/assets/svgs/common/summary.svg';
-import decodeHtml from '@/utils/decodeHtml';
 
 const NewsListPage = () => {
   const nav = useNavigate();
@@ -27,7 +26,7 @@ const NewsListPage = () => {
               nav(`/news/${index}`);
             }}
           >
-            <h2 className="text-base font-medium">{news.news_title || ''}</h2>
+            <h2 className="text-base font-medium overflow-hidden text-ellipsis whitespace-nowrap">{news.news_title || ''}</h2>
             <div className="flex items-center space-x-1 py-1">
               <img src={summary} className="w-[14px]" />
               <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-[#484848]">


### PR DESCRIPTION
## 📎 작업 내용
- BoardList, NewsList 제목 말줄임처리

## 📷 작업 화면 스크린샷
- NewsList UI
<img width="286" alt="스크린샷 2025-02-26 13 27 00" src="https://github.com/user-attachments/assets/19012e1a-942f-444b-b569-d45b5f352b81" />
- BoardList UI
![image](https://github.com/user-attachments/assets/fd40203d-5112-4c56-a7c0-400d771f2aa7)

